### PR TITLE
Add numericFormat feature for better Dependabot support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,11 +36,11 @@ java {
   targetCompatibility = JavaVersion.VERSION_17
 }
 
-kotlin {
-  compilerOptions {
-    jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-  }
-}
+//kotlin {
+//  compilerOptions {
+//    jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+//  }
+//}
 
 tasks.withType(Test::class) {
   useJUnitPlatform()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,11 +36,11 @@ java {
   targetCompatibility = JavaVersion.VERSION_17
 }
 
-//kotlin {
-//  compilerOptions {
-//    jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-//  }
-//}
+kotlin {
+  compilerOptions {
+    jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+  }
+}
 
 tasks.withType(Test::class) {
   useJUnitPlatform()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,12 @@ java {
   targetCompatibility = JavaVersion.VERSION_17
 }
 
+kotlin {
+  compilerOptions {
+    jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+  }
+}
+
 tasks.withType(Test::class) {
   useJUnitPlatform()
 }

--- a/src/main/kotlin/de/europace/gradle/artifactversion/ArtifactVersionExtension.kt
+++ b/src/main/kotlin/de/europace/gradle/artifactversion/ArtifactVersionExtension.kt
@@ -1,0 +1,10 @@
+package de.europace.gradle.artifactversion
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import javax.inject.Inject
+
+abstract class ArtifactVersionExtension @Inject constructor(objects: ObjectFactory) {
+
+  val numericFormat: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+}

--- a/src/main/kotlin/de/europace/gradle/artifactversion/ArtifactVersionPlugin.kt
+++ b/src/main/kotlin/de/europace/gradle/artifactversion/ArtifactVersionPlugin.kt
@@ -14,17 +14,27 @@ open class ArtifactVersionPlugin : Plugin<Project> {
       project.logger.warn("This plugin should only be applied to the root project")
     }
 
-    val artifactVersion = now().format(ofPattern("yyyy-MM-dd\'T\'HH-mm-ss"))
+    val extension = project.extensions.create("artifactVersion", ArtifactVersionExtension::class.java)
 
+    val timestamp = now()
+    val defaultVersion = timestamp.format(ofPattern("yyyy-MM-dd\'T\'HH-mm-ss"))
     project.allprojects {
-      it.logger.info("Setting version " + artifactVersion + " to project " + it.path)
-      it.version = artifactVersion
+      it.logger.info("Setting version " + defaultVersion + " to project " + it.path)
+      it.version = defaultVersion
     }
 
     project.pluginManager.apply(PublishingPlugin::class.java)
     project.afterEvaluate {
+      val artifactVersion = if (extension.numericFormat.get()) {
+        timestamp.format(ofPattern("yyyyMMddHHmmss")).also { v ->
+          project.allprojects { it.version = v }
+        }
+      } else {
+        defaultVersion
+      }
+
       val versionFileTask = project.tasks.register(CREATE_ARTIFACT_VERSION_FILE_TASK_NAME, CreateArtifactVersionFileTask::class.java) {
-        it.artifactVersion = project.version as String
+        it.artifactVersion = artifactVersion
         it.versionFile = project.rootDir.resolve("${project.name}-version.txt")
       }
       project.tasks.findByName(PUBLISH_LIFECYCLE_TASK_NAME)?.dependsOn(versionFileTask)

--- a/src/test/groovy/de/europace/gradle/artifactversion/ArtifactVersionPluginSpec.groovy
+++ b/src/test/groovy/de/europace/gradle/artifactversion/ArtifactVersionPluginSpec.groovy
@@ -89,6 +89,93 @@ class ArtifactVersionPluginSpec extends Specification {
     !new File(testProjectDir, "build/${testProjectDir.name}-version.txt").exists()
   }
 
+  def "default version format is dashed timestamp"() {
+    given:
+    buildFile << """
+        plugins {
+            id '${PLUGIN_ID}'
+        }
+
+        task logVersion {
+           doFirst {
+               logger.lifecycle("LOG_VERSION: \${project.version}")
+           }
+        }
+    """
+
+    when:
+    def result = GradleRunner.create()
+        .withProjectDir(testProjectDir)
+        .withPluginClasspath()
+        .withArguments("logVersion")
+        .forwardOutput()
+        .build()
+
+    then:
+    def projectVersion = getLoggedValue(result, "LOG_VERSION: ")
+    projectVersion ==~ /\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}/
+  }
+
+  def "numeric format produces pure numeric timestamp"() {
+    given:
+    buildFile << """
+        plugins {
+            id '${PLUGIN_ID}'
+        }
+
+        artifactVersion {
+            numericFormat = true
+        }
+
+        task logVersion {
+           doFirst {
+               logger.lifecycle("LOG_VERSION: \${project.version}")
+           }
+        }
+    """
+
+    when:
+    def result = GradleRunner.create()
+        .withProjectDir(testProjectDir)
+        .withPluginClasspath()
+        .withArguments("logVersion")
+        .forwardOutput()
+        .build()
+
+    then:
+    def projectVersion = getLoggedValue(result, "LOG_VERSION: ")
+    projectVersion ==~ /\d{14}/
+  }
+
+  def "numeric format version is written to version file"() {
+    given:
+    buildFile << """
+        plugins {
+            id '${PLUGIN_ID}'
+        }
+
+        artifactVersion {
+            numericFormat = true
+        }
+    """
+
+    when:
+    def result = GradleRunner.create()
+        .withProjectDir(testProjectDir)
+        .withPluginClasspath()
+        .withArguments("createArtifactVersionFile")
+        .forwardOutput()
+        .build()
+
+    then:
+    result.task(":${CREATE_ARTIFACT_VERSION_FILE_TASK_NAME}").outcome == SUCCESS
+
+    and:
+    def versionFile = new File(testProjectDir, "${testProjectDir.name}-version.txt")
+    versionFile.exists()
+    versionFile.readLines().find { it ==~ /\d{14}/ }
+  }
+
   String getLoggedValue(BuildResult result, String needle) {
     return result.output.readLines().find { it.contains(needle) }.substring(needle.length()).trim()
   }


### PR DESCRIPTION
Nach dieser Anpassung lässt sich in Gradle das Versions-Format auf eine vollnumerische Variante mit der folgenden Konfiguration umstellen:

```
artifactVersion {
  numericFormat = true
}
```

Das ist notwendig, da Dependabot das bisherige Format mit Bindestrichen neuerdings anders klassifiziert (alles nach dem ersten Bindestrich gilt als Classifier) und dadurch keine automatischen Dependency Updates mehr durchgeführt werden können.